### PR TITLE
Fix Memory Leak With DirectInput8Create

### DIFF
--- a/input/CrossbarDirectInput.cpp
+++ b/input/CrossbarDirectInput.cpp
@@ -47,11 +47,11 @@ CrossbarDirectInput::~CrossbarDirectInput()
         VirtualProtect(reinterpret_cast<void*>(field), size, oldProtection, &tempProtection);
     }
 
-	if (pDirectInput)
-	{
-		pDirectInput->Release();
-		pDirectInput = nullptr;
-	}
+    if (pDirectInput)
+    {
+        pDirectInput->Release();
+        pDirectInput = nullptr;
+    }
 }
 
 bool CrossbarDirectInput::AttemptHook()

--- a/input/CrossbarDirectInput.cpp
+++ b/input/CrossbarDirectInput.cpp
@@ -46,6 +46,12 @@ CrossbarDirectInput::~CrossbarDirectInput()
         *(reinterpret_cast<DIGetDeviceData*>(field)) = Real_GetDeviceData;
         VirtualProtect(reinterpret_cast<void*>(field), size, oldProtection, &tempProtection);
     }
+
+	if (pDirectInput)
+	{
+		pDirectInput->Release();
+		pDirectInput = nullptr;
+	}
 }
 
 bool CrossbarDirectInput::AttemptHook()


### PR DESCRIPTION
The memory leak that was being caused is now fixed in Ashita v4. This patch fixes it inside of Crossbar now.